### PR TITLE
allow app to access priv_app_tmpfs

### DIFF
--- a/private/app.te
+++ b/private/app.te
@@ -11,6 +11,9 @@
 # Read system properties managed by zygote.
 allow appdomain zygote_tmpfs:file read;
 
+# Read contacts Managed by Contact
+allow appdomain priv_app_tmpfs:file read;
+
 # WebView and other application-specific JIT compilers
 allow appdomain self:process execmem;
 

--- a/private/priv_app.te
+++ b/private/priv_app.te
@@ -4,6 +4,7 @@
 
 typeattribute priv_app coredomain;
 app_domain(priv_app)
+typeattribute priv_app_tmpfs mlstrustedobject;
 
 # Access the network.
 net_domain(priv_app)


### PR DESCRIPTION
From kernel 4.14, untrusted app need to own read permission
of priv_app_tmpfs to access contacts provied by ContactProvider.
Cts runs in untrusted_app domain, it should to own read permission
to priv_app_tmpfs to complete some test cases.

Jira: None
Test: None

Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>